### PR TITLE
Feat: Add SelectionClientBoundingRectangle bindable property

### DIFF
--- a/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
+++ b/SampleApp/SampleApp.iOS/SampleApp.iOS.csproj
@@ -59,11 +59,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARM64</MtouchArch>
     <CodesignKey>iPhone Developer</CodesignKey>
     <MtouchDebug>true</MtouchDebug>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
-    <CodesignProvision>Vistair Wildcard</CodesignProvision>
+    <CodesignProvision>
+    </CodesignProvision>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>

--- a/SampleApp/SampleApp/Samples/StringDataSample.xaml
+++ b/SampleApp/SampleApp/Samples/StringDataSample.xaml
@@ -5,6 +5,32 @@
              Title="String Data"
              x:Class="SampleApp.Samples.StringDataSample">
 
-    <webview:FormsWebView x:Name="stringContent" ContentType="StringData" />
+    <StackLayout>
+        <StackLayout
+            Orientation="Horizontal"
+            >
+            <Label
+                Text="Editable"
+                HorizontalOptions="FillAndExpand"
+                />
+            <Switch
+                IsToggled="True"
+
+                Toggled="Switch_OnToggled"
+                />
+        </StackLayout>
+        <Label
+            Text="{Binding
+                Source={x:Reference stringContent},
+                Path=SelectionClientBoundingRectangle,
+                StringFormat='Selection: {0}'
+            }"
+            />
+        <webview:FormsWebView
+            x:Name="stringContent"
+
+            ContentType="StringData"
+            />
+    </StackLayout>
 
 </ContentPage>

--- a/SampleApp/SampleApp/Samples/StringDataSample.xaml.cs
+++ b/SampleApp/SampleApp/Samples/StringDataSample.xaml.cs
@@ -9,12 +9,24 @@ namespace SampleApp.Samples
         public StringDataSample()
         {
             InitializeComponent();
+
             stringContent.Source = @"
 <!doctype html>
 <html>
-    <body contenteditable='true'><h1>This is a HTML string</h1></body>
+<head>
+	<meta name='viewport' content='width=device-width, user-scalable=0, initial-scale=1, maximum-scale=1, minimum-scale=1' />
+</head>
+    <body contenteditable='true'>
+		<h1>This is a HTML string</h1>
+	</body>
 </html>
             ";
+        }
+
+        private async void Switch_OnToggled(object sender, ToggledEventArgs e)
+        {
+            await stringContent.InjectJavascriptAsync(
+                $"document.body.setAttribute('contenteditable', '{e.Value.ToString().ToLowerInvariant()}')");
         }
     }
 }

--- a/Xam.Plugin.WebView.Abstractions/FormsWebView.Static.cs
+++ b/Xam.Plugin.WebView.Abstractions/FormsWebView.Static.cs
@@ -58,6 +58,16 @@ namespace Xam.Plugin.WebView.Abstractions
         public static readonly BindableProperty UseWideViewPortProperty = BindableProperty.Create(nameof(UseWideViewPort), typeof(bool), typeof(FormsWebView), false);
 
         /// <summary>
+        /// A bindable property for the SelectionClientBoundingRectangle property.
+        /// </summary>
+        public static readonly BindableProperty SelectionClientBoundingRectangleProperty = BindableProperty.Create(
+            nameof(SelectionClientBoundingRectangle),
+            typeof(Rectangle?),
+            typeof(FormsWebView),
+            default(Rectangle?),
+            defaultBindingMode: BindingMode.OneWayToSource);
+
+        /// <summary>
         /// A dictionary used to add headers which are used throughout all instances of FormsWebView.
         /// </summary>
         public readonly static Dictionary<string, string> GlobalRegisteredHeaders = new Dictionary<string, string>();

--- a/clear-all-bin-and-obj-directories.bat
+++ b/clear-all-bin-and-obj-directories.bat
@@ -1,0 +1,2 @@
+FOR /F "tokens=*" %%G IN ('DIR /B /AD /S bin') DO RMDIR /S /Q "%%G"
+FOR /F "tokens=*" %%G IN ('DIR /B /AD /S obj') DO RMDIR /S /Q "%%G"


### PR DESCRIPTION
NOTE: this appears to have issues if missing a meta viewport tag similar to the one in StringDataSample

Also:
1. added clean bin/obj directories batch file
2. switched iOS provisioning profile to be automatic
3. fixed iOS deployment issue (just target ARM64 architecture)
4. modified StringDataSample to toggle contenteditable attribute
5. modified StringDataSample to display value of new SelectionClientBoundingRectangle bindable property in UI