### PR TITLE
Fix 5 - Droid: InjectJavascriptAsync can return the result of a different call

### DIFF
--- a/Xam.Plugin.WebView.Abstractions/FormsWebView.cs
+++ b/Xam.Plugin.WebView.Abstractions/FormsWebView.cs
@@ -1,8 +1,9 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xam.Plugin.WebView.Abstractions.Delegates;
@@ -158,6 +159,13 @@ namespace Xam.Plugin.WebView.Abstractions
             set => SetValue(SelectionClientBoundingRectangleProperty, value);
         }
 
+        private static SemaphoreSlim InjectJavascriptAsyncSynchronizationSemaphoreSlim { get; }
+
+        static FormsWebView()
+        {
+            InjectJavascriptAsyncSynchronizationSemaphoreSlim = new SemaphoreSlim(1, 1);
+        }
+
         public FormsWebView()
         {
             HorizontalOptions = VerticalOptions = LayoutOptions.FillAndExpand;
@@ -238,12 +246,21 @@ namespace Xam.Plugin.WebView.Abstractions
         /// <returns>A valid string response or string.Empty</returns>
         public async Task<string> InjectJavascriptAsync(string js)
         {
-            if (string.IsNullOrWhiteSpace(js)) return string.Empty;
+            try
+            {
+                await InjectJavascriptAsyncSynchronizationSemaphoreSlim.WaitAsync();
 
-            if (OnJavascriptInjectionRequest != null)
-                return await OnJavascriptInjectionRequest.Invoke(js);
+                if (string.IsNullOrWhiteSpace(js)) return string.Empty;
 
-            return string.Empty;
+                if (OnJavascriptInjectionRequest != null)
+                    return await OnJavascriptInjectionRequest.Invoke(js);
+
+                return string.Empty;
+            }
+            finally
+            {
+                InjectJavascriptAsyncSynchronizationSemaphoreSlim.Release();
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Temporary stopgap solution - Synchronize ALL calls to InjectJavascriptAsync across ALL instances of FormsWebView
NOTE: this is not an ideal solution, as it will cause performance issues under certain conditions where multiple parallel calls to InjectJavascriptAsync are being made across multiple FormsWebView instances as each will have to wait on the other one

FUTURE: change the Android implementation to create a separate JavascriptValueCallback instance for each call to InjectJavascriptAsync

fixes #5 