### PR TITLE
Fix issues with SelectionClientBoundingRectangle

### DIFF
--- a/SampleApp/SampleApp.Droid/SampleApp.Droid.csproj
+++ b/SampleApp/SampleApp.Droid/SampleApp.Droid.csproj
@@ -36,6 +36,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
+    <GenerateSerializationAssemblies>Auto</GenerateSerializationAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Xam.Plugin.WebView.Abstractions/Xam.Plugin.WebView.Abstractions.csproj
+++ b/Xam.Plugin.WebView.Abstractions/Xam.Plugin.WebView.Abstractions.csproj
@@ -5,6 +5,11 @@
     <PackageTargetFallback>$(PackageTargetFallback);portable-net45+win8+wpa81+wp8</PackageTargetFallback>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+
   <ItemGroup>
     <Compile Remove="Messaging\**" />
     <EmbeddedResource Remove="Messaging\**" />


### PR DESCRIPTION
1. constrain returned rectangle to the bounds of the selection handles themselves (issues when selection inside of a Table, for example - was returning the bounds of the table/table row instead of where the selection handle itself was located)
2. fixed issues on iOS where the returned rectangle was (0,0,0,0) when it should have had a value

Also, switch Abstractions project to DebugType of Full

fixes #7 