### PR TITLE
Fix #5 - Droid: InjectJavascriptAsync can return the result of a different call

### DIFF
--- a/SampleApp/SampleApp/MainPage.xaml.cs
+++ b/SampleApp/SampleApp/MainPage.xaml.cs
@@ -178,6 +178,13 @@ namespace SampleApp
                 Title = "Cookie test",
                 Detail = "Clear cookies in the web view"
             });
+
+            Items.Add(new SelectionItem()
+            {
+                Identifier = 22,
+                Title = "Parallel InjectJavascriptAsync invocations test",
+                Detail = "Verifies that parallel InjectJavascriptAsync invocations that return out of order still get the correct corresponding results"
+            });
         }
 
         async void OnItemSelected(object sender, SelectedItemChangedEventArgs e)
@@ -272,6 +279,10 @@ namespace SampleApp
 
                 case 21:
                     await ((NavigationPage)Application.Current.MainPage).PushAsync(new ClearCookieSample());
+                    break;
+
+                case 22:
+                    await ((NavigationPage)Application.Current.MainPage).PushAsync(new TestParallelInjectJavascriptAsyncInvocationsSample());
                     break;
 
                 default:

--- a/SampleApp/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp/SampleApp.csproj
@@ -101,6 +101,9 @@
     <Compile Include="Samples\SourceSwapSample.xaml.cs">
       <DependentUpon>SourceSwapSample.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Samples\TestParallelInjectJavascriptAsyncInvocationsSample.xaml.cs">
+      <DependentUpon>TestParallelInjectJavascriptAsyncInvocationsSample.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Samples\StringDataSample.xaml.cs">
       <DependentUpon>StringDataSample.xaml</DependentUpon>
     </Compile>
@@ -263,6 +266,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Samples\ClearCookieSample.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Samples\TestParallelInjectJavascriptAsyncInvocationsSample.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
       <SubType>Designer</SubType>
     </EmbeddedResource>

--- a/SampleApp/SampleApp/Samples/TestParallelInjectJavascriptAsyncInvocationsSample.xaml
+++ b/SampleApp/SampleApp/Samples/TestParallelInjectJavascriptAsyncInvocationsSample.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:webview="clr-namespace:Xam.Plugin.WebView.Abstractions;assembly=Xam.Plugin.WebView.Abstractions"
+             Title="String Data"
+             x:Class="SampleApp.Samples.TestParallelInjectJavascriptAsyncInvocationsSample">
+
+    <StackLayout>
+        <Button
+            Text="Verify parallel calls return correct results"
+            Clicked="Button_OnClicked"
+            />
+        <webview:FormsWebView x:Name="stringContent" ContentType="StringData" />
+    </StackLayout>
+
+  </ContentPage>

--- a/SampleApp/SampleApp/Samples/TestParallelInjectJavascriptAsyncInvocationsSample.xaml.cs
+++ b/SampleApp/SampleApp/Samples/TestParallelInjectJavascriptAsyncInvocationsSample.xaml.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace SampleApp.Samples
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class TestParallelInjectJavascriptAsyncInvocationsSample : ContentPage
+    {
+        public TestParallelInjectJavascriptAsyncInvocationsSample()
+        {
+            InitializeComponent();
+            stringContent.Source = @"
+<!doctype html>
+<html>
+    <body><h1>This is a HTML string</h1></body>
+</html>
+            ";
+        }
+
+        private async void Button_OnClicked(object sender, EventArgs e)
+        {
+            const string invocation1ExpectedResult = "Invocation1";
+            const string invocation2ExpectedResult = "Invocation2";
+            var invocation1Task = stringContent.InjectJavascriptAsync($@"
+var delay = 3000; /* 3 seconds */
+var start = new Date().getTime();
+while (new Date().getTime() < start + delay);
+'{invocation1ExpectedResult}'");
+            var invocation2Task = stringContent.InjectJavascriptAsync($"'{invocation2ExpectedResult}'");
+
+            var invocation1Result = await invocation1Task;
+            var invocation2Result = await invocation2Task;
+            var didPass =
+                invocation1Result == invocation1ExpectedResult &&
+                invocation2Result == invocation2ExpectedResult;
+
+            await DisplayAlert("Parallel invocations test result",
+                (didPass
+                    ? "PASSED"
+                    : $"FAILED")
+                + $"\r\n\r\ninvocation1Result: {invocation1Result}\r\ninvocation2Result: {invocation2Result}",
+                "OK");
+        }
+    }
+}

--- a/Xam.Plugin.WebView.Abstractions/FormsWebView.cs
+++ b/Xam.Plugin.WebView.Abstractions/FormsWebView.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
-using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Xam.Plugin.WebView.Abstractions.Delegates;
@@ -159,13 +158,6 @@ namespace Xam.Plugin.WebView.Abstractions
             set => SetValue(SelectionClientBoundingRectangleProperty, value);
         }
 
-        private static SemaphoreSlim InjectJavascriptAsyncSynchronizationSemaphoreSlim { get; }
-
-        static FormsWebView()
-        {
-            InjectJavascriptAsyncSynchronizationSemaphoreSlim = new SemaphoreSlim(1, 1);
-        }
-
         public FormsWebView()
         {
             HorizontalOptions = VerticalOptions = LayoutOptions.FillAndExpand;
@@ -246,21 +238,12 @@ namespace Xam.Plugin.WebView.Abstractions
         /// <returns>A valid string response or string.Empty</returns>
         public async Task<string> InjectJavascriptAsync(string js)
         {
-            try
-            {
-                await InjectJavascriptAsyncSynchronizationSemaphoreSlim.WaitAsync();
+            if (string.IsNullOrWhiteSpace(js)) return string.Empty;
 
-                if (string.IsNullOrWhiteSpace(js)) return string.Empty;
+            if (OnJavascriptInjectionRequest != null)
+                return await OnJavascriptInjectionRequest.Invoke(js);
 
-                if (OnJavascriptInjectionRequest != null)
-                    return await OnJavascriptInjectionRequest.Invoke(js);
-
-                return string.Empty;
-            }
-            finally
-            {
-                InjectJavascriptAsyncSynchronizationSemaphoreSlim.Release();
-            }
+            return string.Empty;
         }
 
         /// <summary>

--- a/Xam.Plugin.WebView.Droid/FormsWebViewRenderer.cs
+++ b/Xam.Plugin.WebView.Droid/FormsWebViewRenderer.cs
@@ -30,8 +30,6 @@ namespace Xam.Plugin.WebView.Droid
 
         public static event EventHandler<Android.Webkit.WebView> OnControlChanged;
 
-        JavascriptValueCallback _callback;
-
         public static void Initialize()
         {
             var dt = DateTime.Now;
@@ -83,7 +81,6 @@ namespace Xam.Plugin.WebView.Droid
         void SetupControl()
         {
             var webView = new WebViewEx(Forms.Context);
-            _callback = new JavascriptValueCallback(this);
 
             // https://github.com/SKLn-Rad/Xam.Plugin.WebView.Webview/issues/11
             webView.LayoutParameters = new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent);
@@ -169,32 +166,36 @@ namespace Xam.Plugin.WebView.Droid
         {
             if (Element == null || Control == null) return string.Empty;
 
-            // fire!
-            _callback.Reset();
+            var callback = new JavascriptValueCallback(this);
 
             var response = string.Empty;
             
-            Device.BeginInvokeOnMainThread(() => Control.EvaluateJavascript(js, _callback));
+            Device.BeginInvokeOnMainThread(() => Control.EvaluateJavascript(js, callback));
 
             // wait!
             await Task.Run(() =>
             {
-                while (_callback.Value == null) { }
+                while (callback.Value == null) { }
 
-                // Get the string and strip off the quotes
-                if (_callback.Value is Java.Lang.String)
+                using (callback)
                 {
-                    // Unescape that damn Unicode Java bull.
-                    response = Regex.Replace(_callback.Value.ToString(), @"\\[Uu]([0-9A-Fa-f]{4})", m => char.ToString((char)ushort.Parse(m.Groups[1].Value, NumberStyles.AllowHexSpecifier)));
-                    response = Regex.Unescape(response);
+                    // Get the string and strip off the quotes
+                    if (callback.Value is Java.Lang.String)
+                    {
+                        // Unescape that damn Unicode Java bull.
+                        response = Regex.Replace(
+                            callback.Value.ToString(),
+                            @"\\[Uu]([0-9A-Fa-f]{4})",
+                            m => char.ToString((char) ushort.Parse(m.Groups[1].Value, NumberStyles.AllowHexSpecifier)));
+                        response = Regex.Unescape(response);
 
-                    if (response.Equals("\"null\""))
-                        response = null;
+                        if (response.Equals("\"null\""))
+                            response = null;
 
-                    else if (response.StartsWith("\"") && response.EndsWith("\""))
-                        response = response.Substring(1, response.Length - 2);
+                        else if (response.StartsWith("\"") && response.EndsWith("\""))
+                            response = response.Substring(1, response.Length - 2);
+                    }
                 }
-
             });
 
             // return


### PR DESCRIPTION
1. added sample page which tests this behavior
2. [Droid] modified FormsWebViewRenderer to create a new instance of JavascriptValueCallback for each call to InjectJavascriptAsync
3. revert previous hacky fix which synchronized every call to InjectJavascriptAsync (will cause performance issues)

fixes #5 (corresponding issue in SKLn-Rad repo is 116 - https://github.com/SKLn-Rad/Xam.Plugin.Webview/issues/116)